### PR TITLE
Completed headers that were missing words

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
 						</div>
 
 						<div class="test">
-							<h3>Tooltip created from <code></code></h3>
+							<h3>Tooltip created from <code>data-tooltip-content</code> attribute</h3>
 							<p>
 								<span data-tooltip data-tooltip-content="Modify account settings.">
 									<button data-tooltip-trigger onClick="alert('this would edit something');">
@@ -201,7 +201,7 @@
 						</div>
 
 						<div class="test">
-							<h3>Tooltip created from <code></code></h3>
+							<h3>Tooltip created from <code>data-tooltip-content</code> attribute</h3>
 							<p>
 								<span data-tooltip data-tooltip-content="External link" style="font-size: 1.75em">
 									<a href="#!" data-tooltip-trigger onClick="alert('this would go somewhere');">

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 							Tooltip on buttons and links
 						</h2>
 						<div class="test">
-							<h3>Tooltip hard coded in DOM.</h3>
+							<h3>Tooltip hard coded in DOM</h3>
 							<p>
 								<span data-tooltip>
 									<button type="button" data-tooltip-trigger>
@@ -174,7 +174,7 @@
 						</div>
 
 						<div class="test">
-							<h3>Tooltip hard coded in DOM.</h3>
+							<h3>Tooltip hard coded in DOM</h3>
 							<p>
 								You can try to
 								<span data-tooltip>
@@ -213,7 +213,7 @@
 
 						<div class="test">
 							<h3>
-								Tooltip generated from title attribute
+								Tooltip generated from <code>title</code> attribute
 							</h3>
 							<p>
 								<span data-tooltip>

--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
 
 						<div class="test">
 							<h3>
-								Tooltip generated from title attribute
+								Tooltip generated from <code>title</code> attribute
 							</h3>
 							<label for="petName">
 								Favorite Pet's Name


### PR DESCRIPTION
#### The issue

<figure>
  <figcaption>
    Two of the `h3`s in the HTML document were missing some words:
  </figcaption>

  <img width="771" alt="" src="https://user-images.githubusercontent.com/30028540/66708490-f841c980-ed48-11e9-9dcf-a566f83c6dfb.png">
</figure>

#### The fix

<figure>
  <figcaption>
    I completed these two headings, based on how the script works:
  </figcaption>

  <img width="619" alt="" src="https://user-images.githubusercontent.com/30028540/66708464-ae58e380-ed48-11e9-9ee4-a652a2a92d63.png">
</figure>


